### PR TITLE
Fix a minor issue: FormatUri is not updating all required parameters …

### DIFF
--- a/SW.FluentOlap/Services/HttpService.cs
+++ b/SW.FluentOlap/Services/HttpService.cs
@@ -159,13 +159,13 @@ namespace SW.FluentOlap.Models
         /// <returns></returns>
         private Uri FormatUri(object parameters)
         {
-            string formattedUrl = null;
-            
+            string formattedUrl = templatedUrl;
+
             //All values between curly braces are treated as variables
 
             var requiredParameters = GetRequiredParameters(false);
             if (requiredParameters.Count() == 0) return new Uri(templatedUrl);
-                
+
             foreach (string capture in requiredParameters)
             {
                 JToken token = JToken.FromObject(parameters);
@@ -175,7 +175,7 @@ namespace SW.FluentOlap.Models
                 if (!capture.Contains('.'))
                 {
                     string val = token[FormatParameter(capture)]?.Value<string>();
-                    formattedUrl = templatedUrl.Replace(capture, val);
+                    formattedUrl = formattedUrl.Replace(capture, val);
 
                 }
                 else
@@ -183,7 +183,7 @@ namespace SW.FluentOlap.Models
                     JToken val = null;
                     foreach (string depthKey in capture.Split('.'))
                         val = token[depthKey];
-                    formattedUrl = templatedUrl.Replace(capture, val!.Value<string>());
+                    formattedUrl = formattedUrl.Replace(capture, val!.Value<string>());
                 }
             }
             return new Uri(formattedUrl);


### PR DESCRIPTION
The variable `formattedUrl` initialized with null in the method, when replacing the variable template, the `Replace` method called on another variable `templatedUrl` (which is the original uri) each time and the result is stored in `formattedUrl`. This will cause only the last variable value to be persisted.